### PR TITLE
Core Data : Light weight migration with entity attribute name change.

### DIFF
--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcodeproj/project.pbxproj
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		B7352F172BB07D470011587D /* DirectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectorViewModel.swift; sourceTree = "<group>"; };
 		B7369E8A2C4CA84A00F88AD8 /* MovieTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieTableViewCell.swift; sourceTree = "<group>"; };
 		B7369E8B2C4CA84A00F88AD8 /* MovieTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MovieTableViewCell.xib; sourceTree = "<group>"; };
+		B7369E8F2C4D3EF700F88AD8 /* LearningAppCoreDataUIKit_v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = LearningAppCoreDataUIKit_v2.xcdatamodel; sourceTree = "<group>"; };
 		B78189672B9BEC120060A522 /* AddMovieViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMovieViewController.swift; sourceTree = "<group>"; };
 		B7BD74862B9821BE002BC6C0 /* LearningAppCoreDataUIKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LearningAppCoreDataUIKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7BD74892B9821BE002BC6C0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -706,9 +707,10 @@
 		B7BD74922B9821BE002BC6C0 /* LearningAppCoreDataUIKit.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				B7369E8F2C4D3EF700F88AD8 /* LearningAppCoreDataUIKit_v2.xcdatamodel */,
 				B7BD74932B9821BE002BC6C0 /* LearningAppCoreDataUIKit.xcdatamodel */,
 			);
-			currentVersion = B7BD74932B9821BE002BC6C0 /* LearningAppCoreDataUIKit.xcdatamodel */;
+			currentVersion = B7369E8F2C4D3EF700F88AD8 /* LearningAppCoreDataUIKit_v2.xcdatamodel */;
 			path = LearningAppCoreDataUIKit.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/AppDelegate.swift
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/AppDelegate.swift
@@ -42,21 +42,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          error conditions that could cause the creation of the store to fail.
         */
         let container = NSPersistentContainer(name: "LearningAppCoreDataUIKit")
+        let description = NSPersistentStoreDescription()
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
+        /*
+         This doesn't works
+         container.persistentStoreDescriptions = [description]
+         */
+        container.persistentStoreDescriptions.append(description)
         container.viewContext.undoManager = UndoManager()
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
+                print("Error occured while loading persistent container")
+                print("Unresolved error \(error), \(error.userInfo)")
             }
         })
         return container

--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcdatamodeld/.xccurrentversion
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>LearningAppCoreDataUIKit.xcdatamodel</string>
+	<string>LearningAppCoreDataUIKit_v2.xcdatamodel</string>
 </dict>
 </plist>

--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcdatamodeld/LearningAppCoreDataUIKit_v2.xcdatamodel/contents
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit.xcdatamodeld/LearningAppCoreDataUIKit_v2.xcdatamodel/contents
@@ -9,7 +9,7 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="length" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
-        <attribute name="yearOfRelease" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="year" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" elementID="yearOfRelease"/>
         <relationship name="director" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Director" inverseName="movies" inverseEntity="Director"/>
     </entity>
 </model>

--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/Movies/MoviesViewController.swift
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/Movies/MoviesViewController.swift
@@ -75,7 +75,7 @@ extension MoviesViewController: UITableViewDelegate {
         let cell = tableView.dequeueReusableCell(withIdentifier: "movieTableViewCell", for: indexPath) as! MovieTableViewCell
         cell.title.text = viewModel.movies[indexPath.row].title
         cell.director.text = viewModel.movies[indexPath.row].director?.name
-        cell.year.text = String(viewModel.movies[indexPath.row].yearOfRelease)
+        cell.year.text = String(viewModel.movies[indexPath.row].year)
         return cell
     }
     

--- a/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/Movies/MoviesViewModel.swift
+++ b/LearningAppCoreDataUIKit/LearningAppCoreDataUIKit/Movies/MoviesViewModel.swift
@@ -82,7 +82,7 @@ class MoviesViewModel: MoviesViewModelProtocol {
         newMovie.id = UUID()
         newMovie.title = title
         newMovie.length = length
-        newMovie.yearOfRelease = yearOfRelease
+        newMovie.year = yearOfRelease
         if let movieDirector = fetch(director: director) {
             newMovie.director = movieDirector
         }


### PR DESCRIPTION
1. Added a new data model version LearningAppCoreDataUIKit_v2.
2. Updated code to use property attribute year instead of yearOfRelease.
3. In new data model version LearningAppCoreDataUIKit_v2 for renamed attribute year, provided the Renaming ID as yearOfRelease to migrate data.
4. Modified core data stack to include migration options to perform automatic migration.