### PR TITLE
Xcodegen : Add macOS target.

### DIFF
--- a/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/Contents.json
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMac/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMac/ContentView.swift
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMac/ContentView.swift
@@ -1,0 +1,25 @@
+//
+//  ContentView.swift
+//  LearningToolsXcodegenMac
+//
+//  Created by Saurabh Verma on 12/01/26.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, macOS!")
+        }
+        .padding()
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMac/LearningToolsXcodegenMacApp.swift
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMac/LearningToolsXcodegenMacApp.swift
@@ -1,0 +1,17 @@
+//
+//  LearningToolsXcodegenMacApp.swift
+//  LearningToolsXcodegenMac
+//
+//  Created by Saurabh Verma on 12/01/26.
+//
+
+import SwiftUI
+
+@main
+struct LearningToolsXcodegenMacApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMacTests/LearningToolsXcodegenMacTests.swift
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMacTests/LearningToolsXcodegenMacTests.swift
@@ -1,0 +1,17 @@
+//
+//  LearningToolsXcodegenMacTests.swift
+//  LearningToolsXcodegenMacTests
+//
+//  Created by Saurabh Verma on 12/01/26.
+//
+
+import Testing
+@testable import LearningToolsXcodegenMac
+
+struct LearningToolsXcodegenMacTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/LearningToolsXcodegen/LearningToolsXcodegenMacUITests/LearningToolsXcodegenMacUITests.swift
+++ b/LearningToolsXcodegen/LearningToolsXcodegenMacUITests/LearningToolsXcodegenMacUITests.swift
@@ -1,0 +1,41 @@
+//
+//  LearningToolsXcodegenMacUITests.swift
+//  LearningToolsXcodegenMacUITests
+//
+//  Created by Saurabh Verma on 12/01/26.
+//
+
+import XCTest
+
+final class LearningToolsXcodegenMacUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it's important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch the application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/LearningToolsXcodegen/XCODEGEN_TODO.md
+++ b/LearningToolsXcodegen/XCODEGEN_TODO.md
@@ -1,0 +1,228 @@
+# XcodeGen Implementation TODO List
+
+This document tracks all potential XcodeGen features that can be implemented in the LearningToolsXcodegen project.
+
+## Status Legend
+- ⬜ Pending
+- 🔄 In Progress
+- ✅ Completed
+- ❌ Cancelled
+
+---
+
+## 1. Multi-Platform Support
+
+- [ ] **multi-platform-macos** - Add macOS target support to project.yml
+- [ ] **multi-platform-tvos** - Add tvOS target support to project.yml
+- [ ] **multi-platform-watchos** - Add watchOS target support to project.yml
+- [ ] **multi-platform-visionos** - Add visionOS target support to project.yml
+- [ ] **multi-platform-shared** - Implement multi-platform project with shared code structure
+
+## 2. Build Configurations
+
+- [ ] **build-config-staging** - Add Staging build configuration to project.yml
+- [ ] **build-config-beta** - Add Beta build configuration to project.yml
+- [ ] **build-config-development** - Add Development build configuration to project.yml
+- [ ] **build-config-per-config-settings** - Configure per-configuration build settings (Debug vs Release vs Staging)
+
+## 3. Advanced Build Settings
+
+- [ ] **xcconfig-integration** - Integrate .xcconfig files for layered configuration management
+- [ ] **build-settings-groups** - Create build setting groups for reusable configuration
+- [ ] **build-settings-conditional** - Add conditional build settings based on SDK/platform
+
+## 4. Modular Architecture
+
+- [ ] **framework-targets** - Add framework targets for internal modules
+- [ ] **static-library-targets** - Add static library targets to project.yml
+- [ ] **shared-framework-deps** - Configure shared framework dependencies across targets
+- [ ] **multi-module-structure** - Implement multi-module project structure
+
+## 5. App Extensions
+
+- [ ] **extension-widget** - Add Widget extension target
+- [ ] **extension-notification-service** - Add Notification Service extension target
+- [ ] **extension-notification-content** - Add Notification Content extension target
+- [ ] **extension-share** - Add Share extension target
+- [ ] **extension-intents** - Add Intents extension target
+- [ ] **extension-app-clip** - Add App Clip target
+
+## 6. Build Phases
+
+- [ ] **build-phase-run-script** - Add Run Script build phases (pre-build/post-build)
+- [ ] **build-phase-copy-files** - Add Copy Files build phases
+- [ ] **build-phase-headers** - Configure Headers phase for framework targets
+- [ ] **build-phase-compile-sources** - Customize Compile Sources phase configuration
+- [ ] **build-phase-resources** - Customize Resources phase configuration
+
+## 7. Advanced Dependencies
+
+- [ ] **spm-multiple-packages** - Add multiple Swift Package Manager packages
+- [ ] **system-frameworks** - Link system frameworks (UIKit, Foundation, etc.)
+- [ ] **external-frameworks-cocoapods** - Integrate CocoaPods dependencies
+- [ ] **external-frameworks-carthage** - Integrate Carthage dependencies
+- [ ] **spm-local-packages** - Add local package dependencies
+- [ ] **spm-git-branches** - Configure Git-based package dependencies with specific branches/tags
+
+## 8. Entitlements & Capabilities
+
+- [ ] **entitlements-file** - Configure entitlements file per target/config
+- [ ] **capability-app-groups** - Add App Groups capability
+- [ ] **capability-keychain-sharing** - Add Keychain Sharing capability
+- [ ] **capability-push-notifications** - Add Push Notifications capability
+- [ ] **capability-background-modes** - Add Background Modes capability
+- [ ] **capability-associated-domains** - Add Associated Domains capability
+- [ ] **capability-in-app-purchase** - Add In-App Purchase capability
+- [ ] **capability-sign-in-apple** - Add Sign in with Apple capability
+
+## 9. Advanced Scheme Configuration
+
+- [ ] **scheme-launch-arguments** - Configure launch arguments per scheme
+- [ ] **scheme-environment-variables** - Configure environment variables per scheme
+- [ ] **scheme-custom-executable** - Configure different executable per scheme
+- [ ] **scheme-working-directory** - Set custom working directory for schemes
+- [ ] **scheme-debugger-settings** - Configure debugger settings in schemes
+- [ ] **scheme-test-plan** - Configure test plan in schemes
+- [ ] **scheme-multiple-test-targets** - Configure multiple test targets with different configurations
+
+## 10. Resources Management
+
+- [ ] **resources-storyboards** - Add Storyboard files support
+- [ ] **resources-xibs** - Add XIB files support
+- [ ] **resources-localized** - Add localized resources (strings, images)
+- [ ] **resources-tags** - Configure resource tags
+- [ ] **resources-on-demand** - Configure on-demand resources
+- [ ] **resources-excluded-files** - Configure excluded files/folders
+- [ ] **resources-custom-groups** - Create custom resource file groups
+
+## 11. Info.plist Management
+
+- [ ] **infoplist-custom-file** - Use custom Info.plist file instead of generated
+- [ ] **infoplist-additional-keys** - Add additional Info.plist keys
+- [ ] **infoplist-per-config** - Configure per-configuration Info.plist values
+- [ ] **infoplist-url-schemes** - Configure URL schemes in Info.plist
+- [ ] **infoplist-document-types** - Configure document types in Info.plist
+- [ ] **infoplist-utis** - Configure exported/imported UTIs in Info.plist
+
+## 12. File Organization
+
+- [ ] **file-organization-groups** - Create custom file groups and folder structure
+- [ ] **file-organization-exclusions** - Configure file exclusions (files not included in build)
+- [ ] **file-organization-attributes** - Configure file attributes (compiler flags per file)
+- [ ] **file-organization-header-visibility** - Configure header file visibility (public/private/project)
+- [ ] **file-organization-source-flags** - Configure source file compiler flags
+
+## 13. Workspace Support
+
+- [ ] **workspace-multi-project** - Create multi-project workspace
+- [ ] **workspace-cross-project-refs** - Configure cross-project references
+- [ ] **workspace-shared-schemes** - Configure shared schemes across projects
+
+## 14. Advanced Code Signing
+
+- [ ] **codesigning-manual** - Configure manual code signing settings
+- [ ] **codesigning-provisioning** - Configure provisioning profile settings
+- [ ] **codesigning-development-team** - Configure development team settings
+- [ ] **codesigning-per-config** - Configure code signing identity per configuration
+
+## 15. Testing Enhancements
+
+- [ ] **testing-multiple-targets** - Add multiple test targets
+- [ ] **testing-test-plans** - Configure test plans
+- [ ] **testing-test-host** - Configure test host settings
+- [ ] **testing-bundle-settings** - Configure test bundle settings
+- [ ] **testing-code-coverage** - Configure code coverage settings
+
+## 16. Localization
+
+- [ ] **localization-base** - Configure base localization
+- [ ] **localization-multiple-languages** - Add multiple language support
+- [ ] **localization-strings** - Add localized strings files
+- [ ] **localization-assets** - Configure localized asset catalogs
+
+## 17. Scripting & Automation
+
+- [ ] **scripting-pre-build** - Add pre-build scripts (e.g., code generation)
+- [ ] **scripting-post-build** - Add post-build scripts (e.g., asset processing)
+- [ ] **scripting-build-phase** - Add build phase scripts with shell commands
+- [ ] **scripting-input-output** - Configure script input/output files
+
+## 18. Advanced Source Management
+
+- [ ] **source-compiler-flags** - Configure source file compiler flags
+- [ ] **source-header-search-paths** - Configure header search paths
+- [ ] **source-framework-search-paths** - Configure framework search paths
+- [ ] **source-library-search-paths** - Configure library search paths
+- [ ] **source-swift-module-paths** - Configure Swift module search paths
+
+## 19. Project Templates & Reusability
+
+- [ ] **templates-variables** - Use template variables for project configuration
+- [ ] **templates-project-includes** - Use project includes for shared configuration
+- [ ] **templates-yaml-anchors** - Use YAML anchors and aliases for DRY configuration
+
+## 20. CI/CD Optimizations
+
+- [ ] **cicd-build-number** - Implement build number automation
+- [ ] **cicd-version-bumping** - Add version bumping scripts
+- [ ] **cicd-automated-schemes** - Implement automated scheme generation
+- [ ] **cicd-test-reporting** - Configure test reporting for CI/CD
+
+## 21. Advanced Options
+
+- [ ] **advanced-last-upgrade** - Configure last upgrade check version
+- [ ] **advanced-last-swift-update** - Configure last Swift update check
+- [ ] **advanced-organization-name** - Set organization name in project options
+- [ ] **advanced-project-references** - Configure project references
+- [ ] **advanced-file-encoding** - Configure file encoding settings
+- [ ] **advanced-line-endings** - Configure line ending settings
+
+## 22. Debugging & Development
+
+- [ ] **debugging-debug-info** - Configure debug information format settings
+- [ ] **debugging-optimization-levels** - Configure optimization levels per configuration
+- [ ] **debugging-swift-optimization** - Configure Swift optimization settings
+- [ ] **debugging-linker-flags** - Configure linker flags
+- [ ] **debugging-linker-settings** - Configure other linker settings
+
+## 23. App Store & Distribution
+
+- [ ] **distribution-archive-settings** - Configure archive settings
+- [ ] **distribution-export-options** - Configure export options
+- [ ] **distribution-app-store-connect** - Prepare App Store Connect API integration
+- [ ] **distribution-version-management** - Implement version and build number management
+
+## 24. Advanced Asset Management
+
+- [ ] **assets-multiple-catalogs** - Add multiple asset catalogs
+- [ ] **assets-app-icons** - Configure app icon sets for different platforms
+- [ ] **assets-launch-screen** - Configure launch screen assets
+- [ ] **assets-color-sets** - Add color sets with dark mode support
+- [ ] **assets-image-sets** - Configure image sets with different scales
+
+## 25. Performance & Optimization
+
+- [ ] **performance-build-optimization** - Configure build optimization settings
+- [ ] **performance-parallel-compilation** - Configure parallel compilation
+- [ ] **performance-module-compilation** - Configure module compilation
+- [ ] **performance-whole-module-optimization** - Configure whole module optimization
+- [ ] **performance-incremental-compilation** - Configure incremental compilation settings
+
+---
+
+## Summary
+
+**Total Items:** 120
+- ⬜ Pending: 120
+- 🔄 In Progress: 0
+- ✅ Completed: 0
+- ❌ Cancelled: 0
+
+---
+
+## Notes
+
+- Each TODO item has a unique ID (e.g., `multi-platform-macos`) for easy tracking
+- Items can be updated by changing the checkbox status and updating the summary
+- This list is based on XcodeGen capabilities documented in `XCODEGEN_CAPABILITIES.md`
+- Current implementation status is documented in `README.md` and `CHANGELOG.md`

--- a/LearningToolsXcodegen/XCODEGEN_TODO.md
+++ b/LearningToolsXcodegen/XCODEGEN_TODO.md
@@ -12,7 +12,7 @@ This document tracks all potential XcodeGen features that can be implemented in 
 
 ## 1. Multi-Platform Support
 
-- [ ] **multi-platform-macos** - Add macOS target support to project.yml
+- [x] **multi-platform-macos** - Add macOS target support to project.yml
 - [ ] **multi-platform-tvos** - Add tvOS target support to project.yml
 - [ ] **multi-platform-watchos** - Add watchOS target support to project.yml
 - [ ] **multi-platform-visionos** - Add visionOS target support to project.yml
@@ -213,9 +213,9 @@ This document tracks all potential XcodeGen features that can be implemented in 
 ## Summary
 
 **Total Items:** 120
-- ⬜ Pending: 120
+- ⬜ Pending: 119
 - 🔄 In Progress: 0
-- ✅ Completed: 0
+- ✅ Completed: 1
 - ❌ Cancelled: 0
 
 ---

--- a/LearningToolsXcodegen/project.yml
+++ b/LearningToolsXcodegen/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.saurabh
   deploymentTarget:
     iOS: "26.0"
+    macOS: "14.0"
   developmentLanguage: en
   xcodeVersion: "16.0"
   usesTabs: false
@@ -90,6 +91,79 @@ targets:
     dependencies:
       - target: LearningToolsXcodegen
 
+  LearningToolsXcodegenMac:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: LearningToolsXcodegenMac
+    dependencies:
+      - package: Alamofire
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.saurabh.LearningToolsXcodegenMac
+      MARKETING_VERSION: "1.0"
+      CURRENT_PROJECT_VERSION: "1"
+      SWIFT_VERSION: "5.0"
+      ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+      GENERATE_INFOPLIST_FILE: true
+      ENABLE_PREVIEWS: true
+      CODE_SIGN_STYLE: Automatic
+      SWIFT_APPROACHABLE_CONCURRENCY: true
+      SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor
+      SWIFT_EMIT_LOC_STRINGS: true
+      SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: true
+      STRING_CATALOG_GENERATE_SYMBOLS: true
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      INFOPLIST_KEY_NSHumanReadableCopyright: ""
+      INFOPLIST_KEY_NSPrincipalClass: NSApplication
+      INFOPLIST_KEY_NSHighResolutionCapable: true
+
+  LearningToolsXcodegenMacTests:
+    type: bundle.unit-test
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: LearningToolsXcodegenMacTests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.saurabh.LearningToolsXcodegenMacTests
+      MARKETING_VERSION: "1.0"
+      CURRENT_PROJECT_VERSION: "1"
+      SWIFT_VERSION: "5.0"
+      GENERATE_INFOPLIST_FILE: true
+      CODE_SIGN_STYLE: Automatic
+      SWIFT_APPROACHABLE_CONCURRENCY: true
+      SWIFT_EMIT_LOC_STRINGS: false
+      SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: true
+      STRING_CATALOG_GENERATE_SYMBOLS: false
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      TEST_HOST: "$(BUILT_PRODUCTS_DIR)/LearningToolsXcodegenMac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LearningToolsXcodegenMac"
+      BUNDLE_LOADER: "$(TEST_HOST)"
+    dependencies:
+      - target: LearningToolsXcodegenMac
+
+  LearningToolsXcodegenMacUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: LearningToolsXcodegenMacUITests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.saurabh.LearningToolsXcodegenMacUITests
+      MARKETING_VERSION: "1.0"
+      CURRENT_PROJECT_VERSION: "1"
+      SWIFT_VERSION: "5.0"
+      GENERATE_INFOPLIST_FILE: true
+      CODE_SIGN_STYLE: Automatic
+      SWIFT_APPROACHABLE_CONCURRENCY: true
+      SWIFT_EMIT_LOC_STRINGS: false
+      SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: true
+      STRING_CATALOG_GENERATE_SYMBOLS: false
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      TEST_TARGET_NAME: LearningToolsXcodegenMac
+    dependencies:
+      - target: LearningToolsXcodegenMac
+
 schemes:
   LearningToolsXcodegen:
     build:
@@ -120,6 +194,42 @@ schemes:
       targets:
         - LearningToolsXcodegenTests
         - LearningToolsXcodegenUITests
+    profile:
+      config: Debug
+    analyze:
+      config: Debug
+    archive:
+      config: Debug
+
+  LearningToolsXcodegenMac:
+    build:
+      targets:
+        LearningToolsXcodegenMac: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - LearningToolsXcodegenMacTests
+        - LearningToolsXcodegenMacUITests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release
+
+  LearningToolsXcodegenMac-Debug:
+    build:
+      targets:
+        LearningToolsXcodegenMac: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - LearningToolsXcodegenMacTests
+        - LearningToolsXcodegenMacUITests
     profile:
       config: Debug
     analyze:


### PR DESCRIPTION
**## Summary**

- Introduce a macOS application target to the project using XcodeGen.
- Mirror the existing iOS app structure on macOS, including test targets and schemes.
- Prepare the project for multi-platform development while keeping configuration fully declarative in `project.yml`.

**## Changes**

- **XcodeGen configuration (`project.yml`)**
  - Added a macOS deployment target under `options.deploymentTarget` (e.g. `macOS: "14.0"`).
  - Created `LearningToolsXcodegenMac` macOS app target:
    - Uses `LearningToolsXcodegenMac` sources directory.
    - Depends on the existing `Alamofire` SPM package.
    - Configured macOS-specific settings:
      - `MACOSX_DEPLOYMENT_TARGET`
      - App icon and accent color asset catalog settings.
      - Generated Info.plist with macOS keys (e.g. `NSPrincipalClass`, high-resolution capability).
  - Added macOS test targets:
    - `LearningToolsXcodegenMacTests` (unit tests).
    - `LearningToolsXcodegenMacUITests` (UI tests), wired to the macOS app target.
  - Added macOS schemes:
    - `LearningToolsXcodegenMac` (Release/Debug actions).
    - `LearningToolsXcodegenMac-Debug` (Debug-only configuration for all actions).

- **Source & test structure**
  - Added `LearningToolsXcodegenMac/` with:
    - `LearningToolsXcodegenMacApp.swift` – macOS app entry point using SwiftUI.
    - `ContentView.swift` – shared-style SwiftUI view adapted for macOS window sizing.
  - Added `LearningToolsXcodegenMacTests/` with a basic Swift Testing test suite.
  - Added `LearningToolsXcodegenMacUITests/` with an XCTest-based UI test harness.

- **Assets**
  - Added `LearningToolsXcodegenMac/Assets.xcassets`:
    - macOS-specific `AppIcon.appiconset` configuration.
    - `AccentColor.colorset` and root `Contents.json`.

**## Testing**

- Ran `xcodegen generate` to regenerate the Xcode project.
- Opened the project in Xcode and verified:
  - macOS app, unit test, and UI test targets are present.
  - macOS schemes (`LearningToolsXcodegenMac`, `LearningToolsXcodegenMac-Debug`) appear and build the correct targets.
  - macOS app builds and launches successfully on a macOS run destination.